### PR TITLE
Added homescreen-eventview-no-clear-remorse patch

### DIFF
--- a/maintained/homescreen-eventview-no-clear-remorse/patch.json
+++ b/maintained/homescreen-eventview-no-clear-remorse/patch.json
@@ -1,0 +1,8 @@
+{
+    "name": "No remorse for clearing notifications",
+    "description": "A homescreen patch that removes the remorse timer when clearing notifications.",
+    "category": "homescreen",
+    "infos": {
+        "maintainer": "sevanteri"
+    }
+}

--- a/maintained/homescreen-eventview-no-clear-remorse/unified_diff.patch
+++ b/maintained/homescreen-eventview-no-clear-remorse/unified_diff.patch
@@ -1,0 +1,26 @@
+--- original/usr/share/lipstick-jolla-home-qt5/qml/EventsView.qml	2014-07-15 16:58:26.839394563 +0300
++++ patched/usr/share/lipstick-jolla-home-qt5/qml/EventsView.qml	2014-07-15 16:59:25.882397760 +0300
+@@ -90,21 +90,7 @@
+         }
+ 
+         function clearNotifications() {
+-            if (!remorse) {
+-                remorse = remorseComponent.createObject(page)
+-            }
+-
+-            //% "Clearing notifications"
+-            remorse.execute(qsTrId("lipstick-jolla-home-no-clearing-notifications"))
+-        }
+-
+-        Component {
+-            id: remorseComponent
+-
+-            RemorsePopup {
+-                z: 100
+-                onTriggered: verticalNotificationListModel.clearRequested()
+-            }
++            verticalNotificationListModel.clearRequested()
+         }
+ 
+         SilicaListView {
+


### PR DESCRIPTION
Hi again!
I made a small patch that removes the remorse timer from eventsview when clearing notifications.
