### PR TITLE
New Disable Edit Mode patch

### DIFF
--- a/maintained/homescreen-disable-editmode/patch.json
+++ b/maintained/homescreen-disable-editmode/patch.json
@@ -1,0 +1,8 @@
+{
+    "name": "Disable Edit Mode",
+    "description": "Disables edit mode in the menu. You must remove this patch to re-enable. Inspired by similar adjustment for Nokia N900.",
+    "category": "homescreen",
+    "infos": {
+        "maintainer": "Jakub Kožíšek"
+    }
+}

--- a/maintained/homescreen-disable-editmode/unified_diff.patch
+++ b/maintained/homescreen-disable-editmode/unified_diff.patch
@@ -1,0 +1,11 @@
+--- original/usr/share/lipstick-jolla-home-qt5/launcher/LauncherGrid.qml	2015-01-03 23:21:45.000000000 +0100
++++ patched/usr/share/lipstick-jolla-home-qt5/launcher/LauncherGrid.qml	2015-01-03 23:24:19.288757793 +0100
+@@ -287,7 +287,7 @@
+                 }
+             }
+ 
+-            onPressAndHold: setEditMode(true)
++//             onPressAndHold: setEditMode(true)
+ 
+             onPressed: {
+                 // The currentIndex will not be destroyed when we scroll out of view


### PR DESCRIPTION
Adding a new patch. Some community members have complained how easy it is to delete apps on Jolla. This patch is inspired by a tweak for Nokia N900 that disabled any menu changes.
